### PR TITLE
Update Command to Query

### DIFF
--- a/src/TaskFlow.Application/UseCases/TaskCases/GetAllTasksHandler.cs
+++ b/src/TaskFlow.Application/UseCases/TaskCases/GetAllTasksHandler.cs
@@ -6,7 +6,7 @@ using TaskFlow.Domain.Repositories;
 
 namespace TaskFlow.Application.UseCases.TaskCases
 {
-    public class GetAllTasksHandler : IRequestHandler<GetAllTasksCommand, IEnumerable<TaskDTO>>
+    public class GetAllTasksHandler : IRequestHandler<GetAllTasksQuery, IEnumerable<TaskDTO>>
     {
         private readonly ITaskRepository _taskRepository;
         public GetAllTasksHandler(ITaskRepository taskRepository)
@@ -14,7 +14,7 @@ namespace TaskFlow.Application.UseCases.TaskCases
             _taskRepository = taskRepository ?? throw new ArgumentNullException(nameof(taskRepository));
         }
 
-        public async Task<IEnumerable<TaskDTO>> HandleAsync(GetAllTasksCommand request)
+        public async Task<IEnumerable<TaskDTO>> HandleAsync(GetAllTasksQuery request)
         {
             return await _taskRepository.GetAllTasksAsync()
                 .ContinueWith(tasks =>
@@ -24,8 +24,8 @@ namespace TaskFlow.Application.UseCases.TaskCases
                         filteredTasks = filteredTasks.Where(t => t.Status == request.status.Value);
                     if (request.priority.HasValue)
                         filteredTasks = filteredTasks.Where(t => t.Priority == request.priority.Value);
-                    if (request.user != null && user.Id != Guid.Empty)
-                        filteredTasks = filteredTasks.Where(t => t.UserId == request.user.Id);
+                    if (request.user != null && request.user != Guid.Empty)
+                        filteredTasks = filteredTasks.Where(t => t.UserId == request.user);
                     if (request.timeLimit.HasValue)
                         filteredTasks = filteredTasks.Where(t => t.TimeLimit == request.timeLimit.Value);
                     if (request.createdAt.HasValue)

--- a/src/TaskFlow.Application/UseCases/TaskCases/GetAllTasksQuery.cs
+++ b/src/TaskFlow.Application/UseCases/TaskCases/GetAllTasksQuery.cs
@@ -9,10 +9,10 @@ using TaskFlow.Domain.Entities;
 
 namespace TaskFlow.Application.UseCases.TaskCases
 {
-    public record GetAllTasksCommand (
+    public record GetAllTasksQuery (
             Domain.Enums.StatusEnum? status = null,
             Domain.Enums.PriorityEnum? priority = null,
-            User? user = null,
+            Guid? user = null,
             DateTime? timeLimit = null,
             DateTime? createdAt = null
         ) : IRequest<IEnumerable<TaskDTO>>;


### PR DESCRIPTION
Update Command to Query

Also change `user` in query to `Guid`

#### PR Classification
Cambio de consulta en la API.

#### PR Summary
Se ha modificado la clase `GetAllTasksHandler` para cambiar el comando a una consulta, ajustando el tipo de parámetro `user` y actualizando la lógica de filtrado. 
- `GetAllTasksHandler.cs`: Cambio de `GetAllTasksCommand` a `GetAllTasksQuery` y ajuste del tipo de `user` de `User?` a `Guid?`.
- `GetAllTasksHandler.cs`: Actualización de la lógica en `HandleAsync` para filtrar tareas según el nuevo tipo de `user`. 
- `GetAllTasksQuery.cs`: Creación de `GetAllTasksQuery` con nuevos parámetros.
