### PR TITLE
Add Group in memory repository

### DIFF
--- a/src/TaskFlow.Infrastructure/DependencyInjection.cs
+++ b/src/TaskFlow.Infrastructure/DependencyInjection.cs
@@ -10,10 +10,14 @@ namespace TaskFlow.Infrastructure
     {
         public static IServiceCollection AddInfrastructure(this IServiceCollection services)
         {
+            // Registering the TaskFlowMediator as the implementation of IMediator
             services.AddScoped<IMediator, TaskFlowMediator>();
 
+            // Registering repositories with singleton lifetime
             services.AddSingleton<IUserRepository, UserInMemoryRepository>();
             services.AddSingleton<ITaskRepository, TaskInMemoryRepository>();
+            services.AddSingleton<IGroupRepository, GroupInMemoryRepository>();
+
             return services;
         }
     }

--- a/src/TaskFlow.Infrastructure/Repositories/InMemory/GroupInMemoryRepository.cs
+++ b/src/TaskFlow.Infrastructure/Repositories/InMemory/GroupInMemoryRepository.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TaskFlow.Domain.Aggregates;
+using TaskFlow.Domain.Repositories;
+
+namespace TaskFlow.Infrastructure.Repositories.InMemory
+{
+    public class GroupInMemoryRepository : IGroupRepository
+    {
+        private readonly List<Group> _groups;
+        public GroupInMemoryRepository()
+        {
+            _groups = new List<Group>();
+        }
+        public async Task AddAsync(Group group)
+        {
+            _groups.Add(group);
+        }
+        public async Task DeleteAsync(Guid id)
+        {
+            _groups.RemoveAll(g => g.Id == id);
+        }
+        public async Task<Group?> GetByIdAsync(Guid id)
+        {
+            var group = _groups.FirstOrDefault(g => g.Id == id);
+
+            if (group == null)
+            {
+                return null;
+            }
+            return group;
+        }
+        public async Task UpdateAsync(Group group)
+        {
+            var existingGroup = _groups.FirstOrDefault(g => g.Id == group.Id);
+            if (existingGroup != null)
+            {
+                existingGroup = group;
+            }
+            else
+            {
+                throw new KeyNotFoundException($"Group with ID {group.Id} not found.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add Group in memory repository

#### PR Classification
Implementación de un nuevo repositorio en memoria para la gestión de grupos.

#### PR Summary
Se ha añadido la clase `GroupInMemoryRepository` para gestionar operaciones de grupos en memoria y se han registrado nuevos servicios en el contenedor de inyección de dependencias. 
- `GroupInMemoryRepository.cs`: se implementa `IGroupRepository` con métodos para agregar, eliminar, obtener y actualizar grupos.
- `DependencyInjection.cs`: se registra `TaskFlowMediator` como implementación de `IMediator` y `GroupInMemoryRepository` como singleton.
